### PR TITLE
Fix quotes around still_have_issues health check message.

### DIFF
--- a/autoload/health/deoplete.vim
+++ b/autoload/health/deoplete.vim
@@ -30,8 +30,8 @@ endfunction
 
 function! s:still_have_issues() abort
   let indentation = '        '
-  call health#report_info("If you're still having problems, ' .
-        \ 'try the following commands:\n" .
+  call health#report_info("If you're still having problems, " .
+        \ "try the following commands:\n" .
         \ indentation . "$ export NVIM_PYTHON_LOG_FILE=/tmp/log\n" .
         \ indentation . "$ export NVIM_PYTHON_LOG_LEVEL=DEBUG\n" .
         \ indentation . "$ nvim\n" .


### PR DESCRIPTION
The error message is currently rendering incorrectly as you can see here:

![test](https://cloud.githubusercontent.com/assets/6589866/19216413/89e9ab42-8d6f-11e6-93f4-9d9a2f1efd04.png)

I _think_ I did this correctly, but I didn't test it. Please review it is correct. I didn't want to simply post an issue.
